### PR TITLE
Check and close socket before assigning new value

### DIFF
--- a/src/core/transport/http/sender/http_client.c
+++ b/src/core/transport/http/sender/http_client.c
@@ -225,6 +225,11 @@ axis2_http_client_send(
     host = axutil_url_get_host(client->url, env);
     port = axutil_url_get_port(client->url, env);
 
+    if (-1 != client->sockfd)
+    {
+        axutil_network_handler_close_socket(env, client->sockfd);
+        client->sockfd = -1;
+    }
 
     if (client->proxy_enabled)
     {


### PR DESCRIPTION
To prevent orphaned sockets check that the previous client socket is
closed and cleared. Was causing port exhaustion under Windows by leaving
sockets in CLOSE_WAIT state.
